### PR TITLE
Improve README around `site`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It can help you investigate and mitigate performance problems and test failures 
          languages: java
          service-name: my-service
          api-key: ${{ secrets.DD_API_KEY }}
-         site: US1
+         site: datadoghq.com # Change if your site is not US1
      - name: Run unit tests
        run: |
          mvn clean test
@@ -37,10 +37,10 @@ It can help you investigate and mitigate performance problems and test failures 
 The action has the following parameters:
 
 ```yaml
-languages: List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet" (multiple languages can be specified as a space-separated list).
+languages: List of languages to be instrumented. It can be either "all" or any of "java", "js", "python", "dotnet" (multiple languages can be specified as a space-separated list).
 service-name: The name of the service or library being tested.
 api-key: Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys
-site: Datadog site (optional), defaults to US1. See https://docs.datadoghq.com/getting_started/site for more information about sites.
+site: Datadog site (optional), defaults to datadoghq.com. See https://docs.datadoghq.com/getting_started/site for more information about sites. It can be "datadoghq.com", "us3.datadoghq.com", "us5.datadoghq.com", "datadoghq.eu" or "ap1.datadoghq.com".
 ```
 
 ### Additional configuration


### PR DESCRIPTION
### What does this PR do?

Improve instructions around site. `US1` is not a valid `DD_SITE` parameter, and we use `inputs.site` directly to pass to `DD_SITE`: https://github.com/DataDog/test-visibility-github-action/blob/8cea2a0c86c31bfa6e90f1440fbfe85d9b1da367/action.yml#L67

### Motivation

Reduce likelihood of invalid config 

### Describe how to test/QA your changes

Check if it makes sense