### PR TITLE
Use consistent naming 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It can help you investigate and mitigate performance problems and test failures 
        with:
          languages: java
          service-name: my-service
-         api-key: ${{ secrets.DD_API_KEY }}
+         dd_api_key: ${{ secrets.DD_API_KEY }}
          site: datadoghq.com # Change if your site is not US1
      - name: Run unit tests
        run: |
@@ -39,8 +39,9 @@ The action has the following parameters:
 ```yaml
 languages: List of languages to be instrumented. It can be either "all" or any of "java", "js", "python", "dotnet" (multiple languages can be specified as a space-separated list).
 service-name: The name of the service or library being tested.
-api-key: Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys
+dd_api_key: Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys
 site: Datadog site (optional), defaults to datadoghq.com. See https://docs.datadoghq.com/getting_started/site for more information about sites. It can be "datadoghq.com", "us3.datadoghq.com", "us5.datadoghq.com", "datadoghq.eu" or "ap1.datadoghq.com".
+api-key (deprecated): Same as `dd_api_key`.
 ```
 
 ### Additional configuration

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,10 @@ inputs:
     required: true
   api-key:
     description: 'Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys'
-    required: true
+    required: false
+  dd_api_key:
+    description: 'Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys'
+    required: false
   site:
     description: 'Datadog site (optional). See https://docs.datadoghq.com/getting_started/site for more information about sites.'
     required: false
@@ -58,7 +61,7 @@ runs:
       shell: bash
       env:
         DD_CIVISIBILITY_INSTRUMENTATION_LANGUAGES: ${{ inputs.languages }}
-        DD_API_KEY: ${{ inputs.api-key }}
+        DD_API_KEY: ${{ inputs.api-key != '' && inputs.api-key || inputs.dd_api_key }}
         DD_SITE: ${{ inputs.site }}
 
     - name: Propagate optional site input to environment variable
@@ -70,7 +73,7 @@ runs:
     - name: Propagate service name and API key from inputs to environment variables
       run: |
         echo "DD_SERVICE=${{ inputs.service-name }}" >> "$GITHUB_ENV"
-        echo "DD_API_KEY=${{ inputs.api-key }}" >> "$GITHUB_ENV"
+        echo "DD_API_KEY=${{ inputs.api-key != '' && inputs.api-key || inputs.dd_api_key }}" >> "$GITHUB_ENV"
         echo "DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER=github" >> "$GITHUB_ENV"
       shell: bash
 


### PR DESCRIPTION

### What does this PR do?

* Add `dd_api_key` input that does the same as `api-key`.
* Use `dd_api_key` in the README.
* Keep `api-key` so usage is not broken for current users.

### Motivation

Fixes #4

### Describe how to test/QA your changes

CI