### PR TITLE
Add optional input to allow fine-grained Java processes instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It can help you investigate and mitigate performance problems and test failures 
    ```yaml
    steps:
      - name: Configure Datadog Test Visibility
-       uses: datadog/test-visibility-github-action@v1.0.5
+       uses: datadog/test-visibility-github-action@v1.0.7
        with:
          languages: java
          service: my-service
@@ -46,6 +46,7 @@ The action has the following parameters:
  | java-tracer-version | The version of Datadog Java tracer to use. Defaults to the latest release. | false | |
  | js-tracer-version | The version of Datadog JS tracer to use. Defaults to the latest release. | false | |
  | python-tracer-version | The version of Datadog Python tracer to use. Defaults to the latest release. | false | |
+ | java-instrumented-build-system | If provided, only the specified build systems will be instrumented (allowed values are `gradle` and `maven`). Otherwise every Java process will be instrumented. | false | |
 
 ### Additional configuration
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   python-tracer-version:
     description: 'The version of Datadog Python tracer to use (optional). Defaults to the latest release.'
     required: false
+  java-instrumented-build-system:
+    description: 'If provided, only the specified build systems will be instrumented (allowed values are `gradle` and `maven`). Otherwise every Java process will be instrumented.'
+    required: false
   # deprecated inputs
   service-name:
     description: 'Deprecated, alias for service'
@@ -96,6 +99,7 @@ runs:
         DD_SET_TRACER_VERSION_JAVA: ${{ inputs.java-tracer-version }}
         DD_SET_TRACER_VERSION_JS: ${{ inputs.js-tracer-version }}
         DD_SET_TRACER_VERSION_PYTHON: ${{ inputs.python-tracer-version }}
+        DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: ${{ inputs.java-instrumented-build-system }}
 
     - name: Propagate optional site input to environment variable
       if: "${{ inputs.site != '' }}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

By default the action instruments every Java process.
There are currently some unresolved issue in the Java tracer that lead to certain utility processes (such as Byte Buddy agent external instrumentation) getting stuck when instrumented.

This PR adds optional `java-instrumented-build-system` input that lets the user tell the script to only instrument specific processes (such as Maven or Gradle builds).
This workaround will help to avoid instrumenting extra processes until the issues in the tracer are resolved.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->