### PR TITLE
Fix installation script checksum verification when running on macos-latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,11 +75,20 @@ runs:
           wget -O "$script_filepath" "$INSTALLATION_SCRIPT_URL"
         else
           >&2 echo "Error: Neither wget nor curl is installed."
-          return 1
+          exit 1
         fi
 
-        if ! echo "$INSTALLATION_SCRIPT_CHECKSUM $script_filepath" | sha256sum --quiet -c -; then 
-          return 1 
+        if command -v sha256sum >/dev/null 2>&1; then
+          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM $script_filepath" | sha256sum --quiet -c -; then
+            exit 1 
+          fi
+        elif command -v shasum >/dev/null 2>&1; then
+          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM  $script_filepath" | shasum --quiet -a 256 -c -; then 
+            exit 1 
+          fi
+        else
+          >&2 echo "Error: Neither sha256sum nor shasum is installed."
+          exit 1
         fi
 
         chmod +x $script_filepath

--- a/action.yml
+++ b/action.yml
@@ -103,8 +103,8 @@ runs:
         DD_SET_TRACER_VERSION_JS: ${{ inputs.js-tracer-version }}
         DD_SET_TRACER_VERSION_PYTHON: ${{ inputs.python-tracer-version }}
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: ${{ inputs.java-instrumented-build-system }}
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v1.sh
-        INSTALLATION_SCRIPT_CHECKSUM: a1edc11da0d00084c05525151aca5d377f86e3461c94d84f6172b760fa61e125
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v2.sh
+        INSTALLATION_SCRIPT_CHECKSUM: 7c888969cf45b4a2340d5cf58afa2e7110a295904ca182724b88a3d19e9bc18d
 
     - name: Propagate optional site input to environment variable
       if: "${{ inputs.site != '' }}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes installation script checksum verification when the job uses `runs-on: macos-latest`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

An [issue](https://github.com/DataDog/test-visibility-github-action/issues/12) was reported.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Mac OS runner for Github actions does not have the `sha256sum` command available, instead it has `shasum`

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tested manually in a job that is configured with `runs-on: macos-latest`.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->