### PR TITLE
Do not offer auto instrumentation for cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Any [additional configuration values](https://docs.datadoghq.com/tracing/trace_c
 
 For security reasons Github [does not allow](https://github.blog/changelog/2023-10-05-github-actions-node_options-is-now-restricted-from-github_env/) actions to alter the `NODE_OPTIONS` environment variable, so you'll have to pass it manually.
 
-### Tracing JS tests (except `vitest`)
+### Tracing JS tests (except `vitest` and `cypress`)
 
 If you're running tests with [vitest](https://github.com/vitest-dev/vitest), go to [Tracing vitest tests](#tracing-vitest-tests).
 
@@ -78,6 +78,8 @@ To work around the `NODE_OPTIONS` limitation, the action provides a separate `DD
   env:
     NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
 ```
+
+**NOTE**: To instrument your [Cypress](https://www.cypress.io/) tests with Datadog test visibility, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript).
 
 ### Tracing vitest tests
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To work around the `NODE_OPTIONS` limitation, the action provides a separate `DD
     NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
 ```
 
-**NOTE**: To instrument your [Cypress](https://www.cypress.io/) tests with Datadog test visibility, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript).
+**NOTE**: To instrument your [Cypress](https://www.cypress.io/) tests with Datadog Test Visibility, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript/?tab=cypress).
 
 ### Tracing vitest tests
 


### PR DESCRIPTION
### What does this PR do?

[Cypress](https://www.cypress.io/) does not support autoinstrumentation, as it does not work with NODE_OPTIONS, so we are adding a note for this.

![Screenshot 2024-09-05 at 16 36 17](https://github.com/user-attachments/assets/7b0292b9-c785-4d9b-adc9-068973b0aa06)
