### PR TITLE
[SDTEST-899] Add Ruby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# <img height="25" src="logos/test_visibility_logo.png" />  Datadog Test Visibility GitHub Action
+# <img height="25" src="logos/test_visibility_logo.png" /> Datadog Test Optimization GitHub Action
 
-GitHub Action that installs and configures [Datadog Test Visibility](https://docs.datadoghq.com/tests/). 
-Supported languages are .NET, Java, Javascript, and Python.
+GitHub Action that installs and configures [Datadog Test Optimization](https://docs.datadoghq.com/tests/).
+Supported languages are .NET, Java, Javascript, Python, and Ruby.
 
-## About Datadog Test Visibility
+## About Datadog Test Optimization
 
-[Test Visibility](https://docs.datadoghq.com/tests/) provides a test-first view into your CI health by displaying important metrics and results from your tests. 
+[Test Optimization](https://docs.datadoghq.com/tests/) provides a test-first view into your CI health by displaying important metrics and results from your tests.
 It can help you investigate and mitigate performance problems and test failures that are most relevant to your work, focusing on the code you are responsible for, rather than the pipelines which run your tests.
 
 ## Usage
 
 1. Set [Datadog API key](https://app.datadoghq.com/organization-settings/api-keys) inside Settings > Secrets as `DD_API_KEY`.
-2. Add a step to your GitHub Actions workflow YAML that uses this action. Set the language and [site](https://docs.datadoghq.com/getting_started/site/) parameters: 
+2. Add a step to your GitHub Actions workflow YAML that uses this action. Set the language and [site](https://docs.datadoghq.com/getting_started/site/) parameters:
 
    ```yaml
    steps:
-     - name: Configure Datadog Test Visibility
+     - name: Configure Datadog Test Optimization
        uses: datadog/test-visibility-github-action@v2
        with:
          languages: java
@@ -26,26 +26,27 @@ It can help you investigate and mitigate performance problems and test failures 
          mvn clean test
    ```
 
-> [!IMPORTANT]  
-> It is best if the new step comes __right before__ the step that runs your tests.
-> Otherwise, installed tracing libraries might be removed by the steps that precede tests execution 
+> [!IMPORTANT]
+> It is best if the new step comes **right before** the step that runs your tests.
+> Otherwise, installed tracing libraries might be removed by the steps that precede tests execution
 > (for example, `actions/checkout` will wipe out whatever was installed in the action workspace).
 
 ## Configuration
 
 The action has the following parameters:
 
-| Name | Description | Required | Default |
-| ---- | ----------- | -------- | ------- |
- | languages | List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet" (multiple languages can be specified as a space-separated list). | true | |
- | api_key | Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys | true | |
- | site | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites. | false | datadoghq.com |
- | service | The name of the service or library being tested. | false | |
- | dotnet-tracer-version | The version of Datadog .NET tracer to use. Defaults to the latest release. | false | |
- | java-tracer-version | The version of Datadog Java tracer to use. Defaults to the latest release. | false | |
- | js-tracer-version | The version of Datadog JS tracer to use. Defaults to the latest release. | false | |
- | python-tracer-version | The version of Datadog Python tracer to use. Defaults to the latest release. | false | |
- | java-instrumented-build-system | If provided, only the specified build systems will be instrumented (allowed values are `gradle`,`maven`,`sbt`,`ant`,`all`). `all` is a special value that instruments every Java process. If this property is not provided, all known build systems will be instrumented (Gradle, Maven, SBT, Ant). | false | |
+| Name                           | Description                                                                                                                                                                                                                                                                                         | Required | Default       |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| languages                      | List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet", "ruby" (multiple languages can be specified as a space-separated list).                                                                                                                       | true     |               |
+| api_key                        | Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys                                                                                                                                                                                                           | true     |               |
+| site                           | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites.                                                                                                                                                                                                 | false    | datadoghq.com |
+| service                        | The name of the service or library being tested.                                                                                                                                                                                                                                                    | false    |               |
+| dotnet-tracer-version          | The version of Datadog .NET tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
+| java-tracer-version            | The version of Datadog Java tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
+| js-tracer-version              | The version of Datadog JS tracer to use. Defaults to the latest release.                                                                                                                                                                                                                            | false    |               |
+| python-tracer-version          | The version of Datadog Python tracer to use. Defaults to the latest release.                                                                                                                                                                                                                        | false    |               |
+| ruby-tracer-version            | The version of datadog-ci Ruby gem to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
+| java-instrumented-build-system | If provided, only the specified build systems will be instrumented (allowed values are `gradle`,`maven`,`sbt`,`ant`,`all`). `all` is a special value that instruments every Java process. If this property is not provided, all known build systems will be instrumented (Gradle, Maven, SBT, Ant). | false    |               |
 
 ### Additional configuration
 
@@ -78,7 +79,7 @@ To work around the `NODE_OPTIONS` limitation, the action provides a separate `DD
     NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
 ```
 
-**NOTE**: To instrument your [Cypress](https://www.cypress.io/) tests with Datadog Test Visibility, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript/?tab=cypress).
+**NOTE**: To instrument your [Cypress](https://www.cypress.io/) tests with Datadog Test Optimization, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript/?tab=cypress).
 
 ### Tracing vitest tests
 

--- a/action.yml
+++ b/action.yml
@@ -116,9 +116,14 @@ runs:
         echo "DD_SITE=${{ inputs.site }}" >> "$GITHUB_ENV"
       shell: bash
 
-    - name: Propagate service name and API key from inputs to environment variables
+    - name: Propagate optional service input to environment variable
+      if: "${{ inputs.service != '' || inputs.service-name != '' }}"
       run: |
         echo "DD_SERVICE=${{ inputs.service-name != '' && inputs.service-name || inputs.service }}" >> "$GITHUB_ENV"
+      shell: bash
+
+    - name: Propagate API key from input to environment variables and set provider
+      run: |
         echo "DD_API_KEY=${{ inputs.api-key != '' && inputs.api-key || inputs.api_key }}" >> "$GITHUB_ENV"
         echo "DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER=github" >> "$GITHUB_ENV"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -107,8 +107,8 @@ runs:
         DD_SET_TRACER_VERSION_PYTHON: ${{ inputs.python-tracer-version }}
         DD_SET_TRACER_VERSION_RUBY: ${{ inputs.ruby-tracer-version }}
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: ${{ inputs.java-instrumented-build-system }}
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v4.sh
-        INSTALLATION_SCRIPT_CHECKSUM: 41c0df6833bd371cbebf38767cf358c94a3fd1547056281e3ae9cade53fb39e2
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v5.sh
+        INSTALLATION_SCRIPT_CHECKSUM: 903f1146fe123a1f7c6accdc48411546eead172f2d577fb41876d29b537eb7d6
 
     - name: Propagate optional site input to environment variable
       if: "${{ inputs.site != '' }}"

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   python-tracer-version:
     description: 'The version of Datadog Python tracer to use (optional). Defaults to the latest release.'
     required: false
+  ruby-tracer-version:
+    description: 'The version of datadog-ci Ruby gem to use (optional). Defaults to the latest release.'
+    required: false
   java-instrumented-build-system:
     description: 'If provided, only the specified build systems will be instrumented (allowed values are `gradle` and `maven`). Otherwise every Java process will be instrumented.'
     required: false
@@ -43,7 +46,7 @@ inputs:
     deprecationMessage: 'api-key input is deprecated, please use api_key instead'
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set GitHub Path
       run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
@@ -80,11 +83,11 @@ runs:
 
         if command -v sha256sum >/dev/null 2>&1; then
           if ! echo "$INSTALLATION_SCRIPT_CHECKSUM $script_filepath" | sha256sum --quiet -c -; then
-            exit 1 
+            exit 1
           fi
         elif command -v shasum >/dev/null 2>&1; then
-          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM  $script_filepath" | shasum --quiet -a 256 -c -; then 
-            exit 1 
+          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM  $script_filepath" | shasum --quiet -a 256 -c -; then
+            exit 1
           fi
         else
           >&2 echo "Error: Neither sha256sum nor shasum is installed."
@@ -102,6 +105,7 @@ runs:
         DD_SET_TRACER_VERSION_JAVA: ${{ inputs.java-tracer-version }}
         DD_SET_TRACER_VERSION_JS: ${{ inputs.js-tracer-version }}
         DD_SET_TRACER_VERSION_PYTHON: ${{ inputs.python-tracer-version }}
+        DD_SET_TRACER_VERSION_RUBY: ${{ inputs.ruby-tracer-version }}
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: ${{ inputs.java-instrumented-build-system }}
         INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v4.sh
         INSTALLATION_SCRIPT_CHECKSUM: 41c0df6833bd371cbebf38767cf358c94a3fd1547056281e3ae9cade53fb39e2
@@ -125,7 +129,7 @@ runs:
         echo '<a target="_blank" title="Datadog Test Visibility" href="https://docs.datadoghq.com/tests/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/DataDog/test-visibility-github-action/main/logos/dd_logo_h_white.svg"><img width="200" alt="Datadog Test Visibility" src="https://raw.githubusercontent.com/DataDog/test-visibility-github-action/main/logos/dd_logo_h_rgb.svg"></picture></a>' >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Installed Test Visibility libraries:" >> $GITHUB_STEP_SUMMARY
-        
+
         if [ ! -z "$DD_TRACER_VERSION_DOTNET" ]; then
           echo "- __.NET:__ $DD_TRACER_VERSION_DOTNET" >> $GITHUB_STEP_SUMMARY
         fi
@@ -137,6 +141,9 @@ runs:
         fi
         if [ ! -z "$DD_TRACER_VERSION_PYTHON" ]; then
           echo "- __Python:__ $DD_TRACER_VERSION_PYTHON" >> $GITHUB_STEP_SUMMARY
+        fi
+        if [ ! -z "$DD_TRACER_VERSION_RUBY" ]; then
+          echo "- __Ruby:__ $DD_TRACER_VERSION_RUBY" >> $GITHUB_STEP_SUMMARY
         fi
         echo "---" >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: 'purple'
 inputs:
   languages:
-    description: 'List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet" (multiple languages can be specified as a space-separated list).'
+    description: 'List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet", "ruby" (multiple languages can be specified as a space-separated list).'
     required: true
   api_key:
     description: 'Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys'


### PR DESCRIPTION
### What does this PR do?

Adds Ruby support to this action

### Motivation

Datadog's Ruby library supports auto-instrumentation now

### Additional Notes

I renamed Datadog Test Visibility to Datadog Test Optimization in the README.

There was a small issue with DD_SERVICE env variable - when service input is not provided it was set to empty string which caused Ruby tracer to break:

```
W, [2024-11-28T12:39:00.279592 #1946]  WARN -- datadog: [datadog] Failed to convert tag: tag 'service:' ends with a colon
```

Now if there is no service input, DD_SERVICE is not set

### Describe how to test/QA your changes

Tested using this branch in a Rails project: 
https://github.com/anmarchenko/quotes-rails/pull/13

Successful auto injected run with the latest version:
https://github.com/anmarchenko/quotes-rails/actions/runs/12137699480/job/33841536010?pr=13