### PR TITLE
[SDTEST-1754] use v10 of installation script to fix printing Ruby library version in the summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,8 +113,8 @@ runs:
         DD_SET_TRACER_VERSION_RUBY: ${{ inputs.ruby-tracer-version }}
         DD_SET_TRACER_VERSION_GO: ${{ inputs.go-tracer-version }}
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: ${{ inputs.java-instrumented-build-system }}
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v9.sh
-        INSTALLATION_SCRIPT_CHECKSUM: dc524d824779b96fee12f6bf28b12f7da5c7095499bb82bc07981bdb60d6623a
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v10.sh
+        INSTALLATION_SCRIPT_CHECKSUM: 6fac0cc8224499a155e7253b936520ae763dce7bfec04900220f1a5a885821fc
 
     - name: Propagate optional site input to environment variable
       if: "${{ inputs.site != '' }}"


### PR DESCRIPTION
### What does this PR do?

Updates installation script to v10

### Motivation

Fix the issue https://github.com/DataDog/test-visibility-install-script/issues/18

### Describe how to test/QA your changes

Test branch: https://github.com/anmarchenko/quotes-rails/pull/18

Test run with Datadog auto instrumentation: https://github.com/anmarchenko/quotes-rails/actions/runs/14192735992?pr=18

Results (job-quotes-rails-test summary uses gha from this branch, job-quotes-rails-system-test uses gha from released tag):

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/314ab1b6-2c8a-4ea7-8937-745c6ffa5f0e" />
