### PR TITLE
Cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ steps:
 
 #### Cache Cleaning
 
-If you encounter issues with cached data, you have two options to clean the cache:
+If you encounter issues with cached data, you can use the `force-cache-refresh` parameter to ignore existing cache entries and create a fresh cache:
 
-1. **Force Cache Refresh**: Use the `force-cache-refresh` parameter to ignore existing cache entries and create a fresh cache:
 ```yaml
 steps:
   - name: Configure Datadog Test Optimization
@@ -81,22 +80,6 @@ steps:
       languages: java
       api_key: ${{ secrets.DD_API_KEY }}
       force-cache-refresh: true
-```
-
-2. **Manual Cache Deletion**: You can manually delete the cache for a specific key using the GitHub Actions Cache API. Create a workflow with the following step:
-```yaml
-steps:
-  - name: Delete Cache
-    uses: actions/github-script@v6
-    with:
-      script: |
-        const cacheKey = 'dd-test-visibility-java-1.0.0-2.0.0-3.0.0-4.0.0-5.0.0-6.0.0'; // Replace with your cache key
-        const response = await github.rest.actions.deleteActionsCacheByKey({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          key: cacheKey
-        });
-        console.log(`Cache deletion response: ${response.status}`);
 ```
 
 ### Additional configuration

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ It can help you investigate and mitigate performance problems and test failures 
 The action has the following parameters:
 
 | Name                           | Description                                                                                                                                                                                                                                                                                         | Required | Default       |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+|--------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
 | languages                      | List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet", "ruby", "go" (multiple languages can be specified as a space-separated list).                                                                                                                 | true     |               |
 | api_key                        | Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys                                                                                                                                                                                                           | true     |               |
 | site                           | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites.                                                                                                                                                                                                 | false    | datadoghq.com |
 | service                        | The name of the service or library being tested.                                                                                                                                                                                                                                                    | false    |               |
-| enable-cache                   | Enable caching of Datadog tracers and dependencies to speed up workflow runs.                                                                                                                                                                                                                       | false    | true          |
-| force-cache-refresh           | Force refresh the cache by ignoring any existing cache entries. Useful when cache contains incorrect data.                                                                                                                                                                                          | false    | false         |
+| cache                          | Enable caching of Datadog tracers and dependencies to speed up workflow runs.                                                                                                                                                                                                                       | false    | true          |
+| force-cache-refresh            | Force refresh the cache by ignoring any existing cache entries. Useful when cache contains incorrect data.                                                                                                                                                                                          | false    | false         |
 | cache-key                      | Custom cache key to use for caching. If not provided, a default key will be generated based on the languages and tracer versions.                                                                                                                                                                   | false    |               |
 | dotnet-tracer-version          | The version of Datadog .NET tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
 | java-tracer-version            | The version of Datadog Java tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
@@ -54,7 +54,7 @@ The action has the following parameters:
 
 ### Caching
 
-The action supports caching of Datadog tracers and dependencies to speed up workflow runs. Caching is enabled by default but can be disabled by setting `enable-cache: false`. The cache key is automatically generated based on the languages and tracer versions, but you can provide a custom cache key using the `cache-key` parameter.
+The action supports caching of Datadog tracers and dependencies to speed up workflow runs. Caching is enabled by default but can be disabled by setting `cache: false`. The cache key is automatically generated based on the languages and tracer versions, but you can provide a custom cache key using the `cache-key` parameter.
 
 Example with custom cache key:
 ```yaml
@@ -64,7 +64,7 @@ steps:
     with:
       languages: java
       api_key: ${{ secrets.DD_API_KEY }}
-      enable-cache: true
+      cache: true
       cache-key: my-custom-cache-key
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The action has the following parameters:
 | site                           | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites.                                                                                                                                                                                                 | false    | datadoghq.com |
 | service                        | The name of the service or library being tested.                                                                                                                                                                                                                                                    | false    |               |
 | enable-cache                   | Enable caching of Datadog tracers and dependencies to speed up workflow runs.                                                                                                                                                                                                                       | false    | true          |
+| force-cache-refresh           | Force refresh the cache by ignoring any existing cache entries. Useful when cache contains incorrect data.                                                                                                                                                                                          | false    | false         |
 | cache-key                      | Custom cache key to use for caching. If not provided, a default key will be generated based on the languages and tracer versions.                                                                                                                                                                   | false    |               |
 | dotnet-tracer-version          | The version of Datadog .NET tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
 | java-tracer-version            | The version of Datadog Java tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
@@ -65,6 +66,37 @@ steps:
       api_key: ${{ secrets.DD_API_KEY }}
       enable-cache: true
       cache-key: my-custom-cache-key
+```
+
+#### Cache Cleaning
+
+If you encounter issues with cached data, you have two options to clean the cache:
+
+1. **Force Cache Refresh**: Use the `force-cache-refresh` parameter to ignore existing cache entries and create a fresh cache:
+```yaml
+steps:
+  - name: Configure Datadog Test Optimization
+    uses: datadog/test-visibility-github-action@v2
+    with:
+      languages: java
+      api_key: ${{ secrets.DD_API_KEY }}
+      force-cache-refresh: true
+```
+
+2. **Manual Cache Deletion**: You can manually delete the cache for a specific key using the GitHub Actions Cache API. Create a workflow with the following step:
+```yaml
+steps:
+  - name: Delete Cache
+    uses: actions/github-script@v6
+    with:
+      script: |
+        const cacheKey = 'dd-test-visibility-java-1.0.0-2.0.0-3.0.0-4.0.0-5.0.0-6.0.0'; // Replace with your cache key
+        const response = await github.rest.actions.deleteActionsCacheByKey({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          key: cacheKey
+        });
+        console.log(`Cache deletion response: ${response.status}`);
 ```
 
 ### Additional configuration

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The action has the following parameters:
 | api_key                        | Datadog API key. Can be found at https://app.datadoghq.com/organization-settings/api-keys                                                                                                                                                                                                           | true     |               |
 | site                           | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites.                                                                                                                                                                                                 | false    | datadoghq.com |
 | service                        | The name of the service or library being tested.                                                                                                                                                                                                                                                    | false    |               |
+| enable-cache                   | Enable caching of Datadog tracers and dependencies to speed up workflow runs.                                                                                                                                                                                                                       | false    | true          |
+| cache-key                      | Custom cache key to use for caching. If not provided, a default key will be generated based on the languages and tracer versions.                                                                                                                                                                   | false    |               |
 | dotnet-tracer-version          | The version of Datadog .NET tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
 | java-tracer-version            | The version of Datadog Java tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
 | js-tracer-version              | The version of Datadog JS tracer to use. Defaults to the latest release.                                                                                                                                                                                                                            | false    |               |
@@ -48,6 +50,22 @@ The action has the following parameters:
 | ruby-tracer-version            | The version of datadog-ci Ruby gem to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
 | go-tracer-version              | The version of Orchestrion to use. Defaults to the latest release.                                                                                                                                                                                                                                  | false    |               |
 | java-instrumented-build-system | If provided, only the specified build systems will be instrumented (allowed values are `gradle`,`maven`,`sbt`,`ant`,`all`). `all` is a special value that instruments every Java process. If this property is not provided, all known build systems will be instrumented (Gradle, Maven, SBT, Ant). | false    |               |
+
+### Caching
+
+The action supports caching of Datadog tracers and dependencies to speed up workflow runs. Caching is enabled by default but can be disabled by setting `enable-cache: false`. The cache key is automatically generated based on the languages and tracer versions, but you can provide a custom cache key using the `cache-key` parameter.
+
+Example with custom cache key:
+```yaml
+steps:
+  - name: Configure Datadog Test Optimization
+    uses: datadog/test-visibility-github-action@v2
+    with:
+      languages: java
+      api_key: ${{ secrets.DD_API_KEY }}
+      enable-cache: true
+      cache-key: my-custom-cache-key
+```
 
 ### Additional configuration
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,13 @@ inputs:
   service:
     description: 'The name of the service or library being tested.'
     required: false
+  enable-cache:
+    description: 'Enable caching of Datadog tracers and dependencies to speed up workflow runs.'
+    required: false
+    default: 'true'
+  cache-key:
+    description: 'Custom cache key to use for caching. If not provided, a default key will be generated based on the languages and tracer versions.'
+    required: false
   dotnet-tracer-version:
     description: 'The version of Datadog .NET tracer to use (optional). Defaults to the latest release.'
     required: false
@@ -57,8 +64,19 @@ runs:
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
+    - name: Set up cache
+      if: ${{ inputs.enable-cache == 'true' }}
+      uses: actions/cache@v3
+      id: cache
+      with:
+        path: ${{ github.workspace }}/.datadog
+        key: ${{ inputs.cache-key || format('dd-test-visibility-{0}-{1}-{2}-{3}-{4}-{5}', inputs.languages, inputs.dotnet-tracer-version, inputs.java-tracer-version, inputs.js-tracer-version, inputs.python-tracer-version, inputs.ruby-tracer-version) }}
+        restore-keys: |
+          dd-test-visibility-${{ inputs.languages }}-
+
     - name: Download and run configuration script
       id: run-configuration-script
+      if: ${{ steps.cache.outputs.cache-hit != 'true' || inputs.enable-cache != 'true' }}
       run: |
         mkdir -p $GITHUB_WORKSPACE/.datadog
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   service:
     description: 'The name of the service or library being tested.'
     required: false
-  enable-cache:
+  cache:
     description: 'Enable caching of Datadog tracers and dependencies to speed up workflow runs.'
     required: false
     default: 'true'
@@ -69,7 +69,7 @@ runs:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
     - name: Set up cache
-      if: ${{ inputs.enable-cache == 'true' && inputs.force-cache-refresh != 'true' }}
+      if: ${{ inputs.cache == 'true' && inputs.force-cache-refresh != 'true' }}
       uses: actions/cache@v3
       id: cache
       with:
@@ -86,7 +86,7 @@ runs:
 
     - name: Download and run configuration script
       id: run-configuration-script
-      if: ${{ steps.cache.outputs.cache-hit != 'true' || inputs.enable-cache != 'true' || inputs.force-cache-refresh == 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' || inputs.cache != 'true' || inputs.force-cache-refresh == 'true' }}
       run: |
         mkdir -p $GITHUB_WORKSPACE/.datadog
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Enable caching of Datadog tracers and dependencies to speed up workflow runs.'
     required: false
     default: 'true'
+  force-cache-refresh:
+    description: 'Force refresh the cache by ignoring any existing cache entries. Useful when cache contains incorrect data.'
+    required: false
+    default: 'false'
   cache-key:
     description: 'Custom cache key to use for caching. If not provided, a default key will be generated based on the languages and tracer versions.'
     required: false
@@ -65,7 +69,7 @@ runs:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
     - name: Set up cache
-      if: ${{ inputs.enable-cache == 'true' }}
+      if: ${{ inputs.enable-cache == 'true' && inputs.force-cache-refresh != 'true' }}
       uses: actions/cache@v3
       id: cache
       with:
@@ -74,9 +78,15 @@ runs:
         restore-keys: |
           dd-test-visibility-${{ inputs.languages }}-
 
+    - name: Clean cache directory if force refresh
+      if: ${{ inputs.force-cache-refresh == 'true' }}
+      run: |
+        rm -rf $GITHUB_WORKSPACE/.datadog
+      shell: bash
+
     - name: Download and run configuration script
       id: run-configuration-script
-      if: ${{ steps.cache.outputs.cache-hit != 'true' || inputs.enable-cache != 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' || inputs.enable-cache != 'true' || inputs.force-cache-refresh == 'true' }}
       run: |
         mkdir -p $GITHUB_WORKSPACE/.datadog
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR introduces caching mechanisms to the GitHub Action to enhance performance by caching Datadog tracers and dependencies. Key changes include:
- Added three new parameters: `cache`, `force-cache-refresh` and `cache-key` in `action.yml`.
- Introduced a caching step using `actions/cache@v3` in the workflow.
- Updated the `README.md` to document the caching feature, including an example configuration.

### Motivation
The aim is to reduce the time taken for workflow runs by leveraging caching capabilities. This will improve efficiency, especially for workflows that frequently use Datadog tracers and dependencies.

### Additional Notes
Documentation has been updated in README.md to include information about the caching feature, its usage, and examples.

### Possible Drawbacks / Trade-offs
- Caching could introduce complexity in scenarios where dependencies or tracers need to be updated but are mistakenly served from the cache.
- The cache key configuration requires careful consideration to avoid conflicts or unintended cache misses.

### Describe how to test/QA your changes

- Configure a GitHub Action workflow with the updated action version.
- Enable caching by setting `cache: true` and optionally providing a custom `cache-key`.
- Run the workflow and verify:
  - The cache is created and restored as expected.
  - The workflow skips downloading dependencies if the cache is available (cache hit).
  - Disabling caching (`cache: false`) bypasses the cache setup step.
- Force cache clean by setting `force-cache-refresh: true`.
- Run the workflow and verify:
  - There is a cache miss and the workflow has to download the dependencies.