### PR TITLE
Enable caching for Go

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,11 +51,40 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set GitHub Path
-      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+    - name: Set global envs and github path
+      run: |
+        echo "INSTALLATION_SCRIPT_URL=$INSTALLATION_SCRIPT_URL" >> $GITHUB_ENV
+        echo "INSTALLATION_SCRIPT_CHECKSUM=$INSTALLATION_SCRIPT_CHECKSUM" >> $GITHUB_ENV
+        echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
       shell: bash
       env:
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v11.sh
+        INSTALLATION_SCRIPT_CHECKSUM: fc64c45fd4b45b4b01773c58a3a116bef212dc4095508a6e27e19e50e901bd55
         GITHUB_ACTION_PATH: ${{ github.action_path }}
+
+    - name: Get Go cache directories
+      if: ${{ contains(inputs.languages, 'go') || inputs.languages == 'all' }}
+      id: go-cache-paths
+      shell: bash
+      run: |
+        echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+        echo "GOMODCACHE_PATH=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+        echo "GOCACHE_PATH=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "GOVERSION=$(go env GOVERSION)" >> $GITHUB_OUTPUT
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_OUTPUT
+
+    - name: Go cache
+      uses: actions/cache@v4
+      if: ${{ contains(inputs.languages, 'go') || inputs.languages == 'all' }}
+      id: go-cache
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.GOMODCACHE_PATH }}
+          ${{ steps.go-cache-paths.outputs.GOCACHE_PATH }}
+          ${{ env.GITHUB_WORKSPACE }}/.datadog
+          /github/workspace/.datadog
+          ${{ steps.go-cache-paths.outputs.GOPATH }}/bin/orchestrion
+        key: test-optimization-go-${{ env.INSTALLATION_SCRIPT_CHECKSUM }}-${{ steps.go-cache-paths.outputs.GOVERSION }}-${{ inputs.go-tracer-version }}-${{ hashFiles('**/go.mod') }}-${{ hashFiles('**/go.sum') }}
 
     - name: Download and run configuration script
       id: run-configuration-script
@@ -113,8 +142,6 @@ runs:
         DD_SET_TRACER_VERSION_RUBY: ${{ inputs.ruby-tracer-version }}
         DD_SET_TRACER_VERSION_GO: ${{ inputs.go-tracer-version }}
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: ${{ inputs.java-instrumented-build-system }}
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v11.sh
-        INSTALLATION_SCRIPT_CHECKSUM: fc64c45fd4b45b4b01773c58a3a116bef212dc4095508a6e27e19e50e901bd55
 
     - name: Propagate optional site input to environment variable
       if: "${{ inputs.site != '' }}"
@@ -161,3 +188,4 @@ runs:
         fi
         echo "---" >> $GITHUB_STEP_SUMMARY
       shell: bash
+

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ inputs:
   java-instrumented-build-system:
     description: 'If provided, only the specified build systems will be instrumented (allowed values are `gradle` and `maven`). Otherwise every Java process will be instrumented.'
     required: false
+  cache:
+    description: 'Enable caching (optional). Defaults to true.'
+    required: false
+    type: boolean
+    default: true
   # deprecated inputs
   service-name:
     description: 'Deprecated, alias for service'
@@ -63,7 +68,7 @@ runs:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
     - name: Get Go cache directories
-      if: ${{ contains(inputs.languages, 'go') || inputs.languages == 'all' }}
+      if: ${{ inputs.cache == 'true' && (contains(inputs.languages, 'go') || inputs.languages == 'all') }}
       id: go-cache-paths
       shell: bash
       run: |
@@ -75,12 +80,11 @@ runs:
 
     - name: Go cache
       uses: actions/cache@v4
-      if: ${{ contains(inputs.languages, 'go') || inputs.languages == 'all' }}
+      if: ${{ inputs.cache == 'true' && (contains(inputs.languages, 'go') || inputs.languages == 'all') }}
       id: go-cache
       with:
         path: |
           ${{ steps.go-cache-paths.outputs.GOMODCACHE_PATH }}
-          ${{ steps.go-cache-paths.outputs.GOCACHE_PATH }}
           ${{ env.GITHUB_WORKSPACE }}/.datadog
           /github/workspace/.datadog
           ${{ steps.go-cache-paths.outputs.GOPATH }}/bin/orchestrion


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR enables caching for Go auto-instrumentation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Processing, pinning and applying the Go instrumentation requires time to download all the orchestrion and dd-trace-go dependencies.

By enabling cache, we can reduce the time to apply autoinstrumentation.

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/5018f9be-565a-453b-9c31-f9407bcdb581" />

In this example we were able to reduce the job time from 4min 48sec to 1min and 15secs. aprox.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

A new `cache` input was added to the action, the default value is `true` but you can disable the cache by setting the key to `false`.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->