### PR TITLE
Add option to disable printing to job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           languages: java
           api_key: "dummy"
           java-instrumented-build-system: "all"
+          print-github-step-summary: false
 
       - name: Check If Java Tracing Works
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
           languages: java
           api_key: "dummy"
           java-instrumented-build-system: "all"
-          print-github-step-summary: false
 
       - name: Check If Java Tracing Works
         run: |

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,11 @@ inputs:
     required: false
     type: boolean
     default: true
+  print-github-step-summary:
+    description: 'Print a summary of the installed tracers to the GitHub step summary, otherwise the summary is printed to console (optional). Defaults to true.'
+    required: false
+    type: boolean
+    default: true
   # deprecated inputs
   service-name:
     description: 'Deprecated, alias for service'
@@ -191,5 +196,10 @@ runs:
           echo "- __Go:__ $DD_TRACER_VERSION_GO" >> $GITHUB_STEP_SUMMARY
         fi
         echo "---" >> $GITHUB_STEP_SUMMARY
+
+        if [ "${{ inputs.print-github-step-summary }}" == "false" ]; then
+          cat $GITHUB_STEP_SUMMARY
+          rm -f $GITHUB_STEP_SUMMARY
+        fi
       shell: bash
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Add the option to not print to the github job summary, instead writing to the console.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Datadog writing to the job summary when multiple runners are running tests in parallel can result in the Github summary being spammed, potentially hiding summaries that are more useful on a day-to-day basis.

Fixes #41 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Optional and defaults to `true`, so the new behavior is "opt-in".

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#removing-job-summaries
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Add `print-github-step-summary: false` to `ci.yml`
https://github.com/DataDog/test-visibility-github-action/actions/runs/15498628113
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->