### PR TITLE
Fix checksum command to strictly follow the required format + remove quiet option not supported in BusyBox implementation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -125,11 +125,11 @@ runs:
         fi
 
         if command -v sha256sum >/dev/null 2>&1; then
-          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM $script_filepath" | sha256sum --quiet -c -; then
+          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM  $script_filepath" | sha256sum -c -; then
             exit 1
           fi
         elif command -v shasum >/dev/null 2>&1; then
-          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM  $script_filepath" | shasum --quiet -a 256 -c -; then
+          if ! echo "$INSTALLATION_SCRIPT_CHECKSUM  $script_filepath" | shasum -a 256 -c -; then
             exit 1
           fi
         else


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes the format of `sha256sum` command input: strict validation requires that there are 2 spaces between the checksum and the filename, so depending on the command version the previous call with only 1 space could fail.

Removes the `--quite` option from the checksum command, as the `sha256sum` version that comes with BusyBox does not support it.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->