### PR TITLE
Pin the cache action to a specific commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_OUTPUT
 
     - name: Go cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 v4
       if: ${{ inputs.cache == 'true' && (contains(inputs.languages, 'go') || inputs.languages == 'all') }}
       id: go-cache
       with:


### PR DESCRIPTION
### What does this PR do?

The "test-visibility-github-action" action uses the [actions/cache](https://github.com/actions/cache) action and pins it to the "v4" tag.

https://github.com/DataDog/test-visibility-github-action/blob/4d09028b08a1f4431663b1de1550249cd4764051/action.yml#L86-L87

My PR updates this to pin "actions/cache" to a specific commit hash instead.

### Motivation

Pinning an action to a tag instead of a commit is a bit more convenient because the tag can be moved by the action owner to the latest release. But for the same reason it's a bit less secure because the tag can also be moved to a compromised version by a malicious actor. Pinning to a specific commit ensures the chosen version can't be altered.

Furthermore, GitHub organizations have the option to enforce this as a mandatory policy. Since our org has that policy enabled, your action is blocked and we aren't able to use it.

### Additional Notes

The ["actions/cache" commit selected](https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830) in this PR is the one currently tagged as "v4" and "v4.3.0".

For more background info:
- [Pinning GitHub Actions for Enhanced Security: Everything You Should Know - StepSecurity](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide)
- [GitHub Actions policy now supports blocking and SHA pinning actions - GitHub Changelog](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)
