### PR TITLE
feat: map job check run id from default context variables to environment variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,7 @@ runs:
       run: |
         echo "INSTALLATION_SCRIPT_URL=$INSTALLATION_SCRIPT_URL" >> $GITHUB_ENV
         echo "INSTALLATION_SCRIPT_CHECKSUM=$INSTALLATION_SCRIPT_CHECKSUM" >> $GITHUB_ENV
+        echo "JOB_CHECK_RUN_ID=${{ job.check_run_id }}" >> $GITHUB_ENV
         echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
       shell: bash
       env:


### PR DESCRIPTION
### What does this PR do?

* Map the job's numeric id from Github Action's default context variables to an environment variable that can be picked up by the tracers

### Motivation

* For some reason, the Github team decided to expose the numeric job id - which is the only means to uniquely identify a job - through the context variables and not the environment variables
* For the customers that use auto-instrumentation, we can map the variable for them, so they get accurate `@ci.job.url` and `@ci.job.id` tags on their test events out of the box. This enables easier navigation and correlation between CI Visibility and Test Optimization jobs